### PR TITLE
Introduce a shared scm context

### DIFF
--- a/lib/chef-cli/cookbook_profiler/git.rb
+++ b/lib/chef-cli/cookbook_profiler/git.rb
@@ -104,16 +104,12 @@ module ChefCLI
       end
 
       private
-      
+
       def repo_directory
-        @repo_directory ||=
-          Pathname.new(@cookbook_path).ascend do |parent_dir|
-            possbile_git_dir = File.join(parent_dir, '.git')
-            if File.directory?(possbile_git_dir)
-              return possbile_git_dir
-            end
-          end
-          @repo_directory
+        @repo_directory ||= Pathname.new(@cookbook_path).ascend do |parent_dir|
+          possible_git_dir = File.join(parent_dir, '.git')
+          break possible_git_dir if File.directory?(possible_git_dir )
+        end
       end
 
       def git!(subcommand, options = {})

--- a/lib/chef-cli/cookbook_profiler/git.rb
+++ b/lib/chef-cli/cookbook_profiler/git.rb
@@ -25,15 +25,16 @@ module ChefCLI
 
       attr_reader :cookbook_path
 
-      def initialize(cookbook_path)
+      def initialize(cookbook_path, shared_scm_context = {})
         @cookbook_path = cookbook_path
         @unborn_branch = nil
         @unborn_branch_ref = nil
+        @shared_scm_context = shared_scm_context
       end
 
       # @return [Hash] Hashed used for pinning cookbook versions within a Policyfile.lock
       def profile_data
-        {
+        @shared_scm_context[repo_directory] ||= {
           "scm" => "git",
           # To get this info, you need to do something like:
           # figure out branch or assume 'main'
@@ -103,6 +104,17 @@ module ChefCLI
       end
 
       private
+      
+      def repo_directory
+        @repo_directory ||=
+          Pathname.new(@cookbook_path).ascend do |parent_dir|
+            possbile_git_dir = File.join(parent_dir, '.git')
+            if File.directory?(possbile_git_dir)
+              return possbile_git_dir
+            end
+          end
+          @repo_directory
+      end
 
       def git!(subcommand, options = {})
         cmd = git(subcommand, options)

--- a/lib/chef-cli/policyfile/cookbook_locks.rb
+++ b/lib/chef-cli/policyfile/cookbook_locks.rb
@@ -62,13 +62,14 @@ module ChefCLI
 
       attr_accessor :version
 
-      def initialize(name, storage_config)
+      def initialize(name, storage_config, shared_scm_context = {})
         @name = name
         @version = nil
         @source_options = nil
         @identifier = nil
         @dotted_decimal_identifier = nil
         @storage_config = storage_config
+        @shared_scm_context = shared_scm_context
       end
 
       def installed?
@@ -280,7 +281,7 @@ module ChefCLI
       # given, it is resolved relative to #relative_paths_root
       attr_accessor :source
 
-      def initialize(name, storage_config)
+      def initialize(name, storage_config, shared_scm_context = {})
         @name = name
         @identifier = nil
         @storage_config = storage_config
@@ -289,6 +290,7 @@ module ChefCLI
         @version_updated = false
         @cookbook_in_git_repo = nil
         @scm_info = nil
+        @shared_scm_context = shared_scm_context
       end
 
       def cookbook_path
@@ -297,7 +299,7 @@ module ChefCLI
 
       def scm_profiler
         if cookbook_in_git_repo?
-          CookbookProfiler::Git.new(cookbook_path)
+          CookbookProfiler::Git.new(cookbook_path, @shared_scm_context)
         else
           CookbookProfiler::NullSCM.new(cookbook_path)
         end

--- a/lib/chef-cli/policyfile/cookbook_locks.rb
+++ b/lib/chef-cli/policyfile/cookbook_locks.rb
@@ -62,14 +62,13 @@ module ChefCLI
 
       attr_accessor :version
 
-      def initialize(name, storage_config, shared_scm_context = {})
+      def initialize(name, storage_config)
         @name = name
         @version = nil
         @source_options = nil
         @identifier = nil
         @dotted_decimal_identifier = nil
         @storage_config = storage_config
-        @shared_scm_context = shared_scm_context
       end
 
       def installed?

--- a/lib/chef-cli/policyfile_lock.rb
+++ b/lib/chef-cli/policyfile_lock.rb
@@ -113,6 +113,8 @@ module ChefCLI
       @included_policy_locks = []
 
       @install_report = InstallReport.new(ui: @ui, policyfile_lock: self)
+
+      @shared_scm_context = {}
     end
 
     def lock_data_for(cookbook_name)
@@ -126,7 +128,7 @@ module ChefCLI
     end
 
     def local_cookbook(name)
-      local_cookbook = Policyfile::LocalCookbook.new(name, storage_config)
+      local_cookbook = Policyfile::LocalCookbook.new(name, storage_config, @shared_scm_context)
       yield local_cookbook if block_given?
       @cookbook_locks[name] = local_cookbook
     end

--- a/spec/unit/cookbook_profiler/git_spec.rb
+++ b/spec/unit/cookbook_profiler/git_spec.rb
@@ -25,8 +25,10 @@ describe ChefCLI::CookbookProfiler::Git do
 
   include ChefCLI::Helpers
 
+  let(:shared_scm_context) { Hash.new }
+  let(:git_repo) { File.join(cookbook_path, '.git') }
   let(:git_profiler) do
-    ChefCLI::CookbookProfiler::Git.new(cookbook_path)
+    ChefCLI::CookbookProfiler::Git.new(cookbook_path, shared_scm_context)
   end
 
   context "with cookbooks in a valid git repo" do
@@ -69,6 +71,34 @@ describe ChefCLI::CookbookProfiler::Git do
 
       it "reports that the repo doesn't have a remote" do
         expect(git_profiler.have_remote?).to be(false)
+      end
+
+    end
+
+    context "when the shared context is used" do
+      
+      let(:shared_scm_context) { instance_double('Hash') }
+
+      it 'should set shared scm context for new cookbook' do
+        expect(shared_scm_context).to receive(:[]).with(git_repo).and_return(nil).once
+        expect(shared_scm_context).to receive(:[]=).once
+        git_profiler.profile_data
+      end
+
+      it 'should use shared scm context if existing' do
+        expect(shared_scm_context).to receive(:[]).with(git_repo).and_return({}).twice
+        git_profiler.profile_data
+        git_profiler.profile_data
+      end
+      
+    end
+
+    context "when a shared context is provided" do
+
+      let(:shared_scm_context) { { git_repo => {"scm"=>"git", "remote"=>nil, "revision"=>"abcdef123456789", "working_tree_clean"=>true, "published"=>false, "synchronized_remote_branches"=>[]} } }
+
+      it 'should return values from it' do
+        expect(git_profiler.profile_data).to eq(shared_scm_context[git_repo])
       end
 
     end


### PR DESCRIPTION
In some situations, when many local cookbooks are used, tests can spend a lot of time doing several times the same git commands for each one of them. It can be particularly inefficient when they share the same git repo.

With this change, we make sure commands are launched only once and results are reused if necessary.

## Description
For each local cookbook, browse the directory tree and look for a git configuration. This scm context is then re-used for other local cookbooks that are sharing the same git configuration folder. 